### PR TITLE
Add support for NANITOR_ENROLL_TOKEN in signup key

### DIFF
--- a/modules/services/nanitor-agent.nix
+++ b/modules/services/nanitor-agent.nix
@@ -160,7 +160,9 @@ in
               echo "[nanitor-agent unit] Setting server URL to '${cfg.enroll.serverUrl}'"
               ${bin} set-server-url ${lib.escapeShellArg cfg.enroll.serverUrl} || echo "[nanitor-agent unit] set-server-url failed (continuing)"
             '' else "";
-          signupKeyArg = if cfg.enroll.key != null then "--key ${lib.escapeShellArg cfg.enroll.key}" else "";
+          signupKeyArg = if cfg.enroll.key != null then "--key ${lib.escapeShellArg cfg.enroll.key}"
+  else if cfg.environment.NANITOR_ENROLL_TOKEN or "" != "" then "--key ''${NANITOR_ENROLL_TOKEN}"
+  else "";
         in lib.mkIf cfg.enroll.enable ''
           set -euo pipefail
           ${serverUrlScript}


### PR DESCRIPTION
Allow passing token via an environment variable. Refs #9 